### PR TITLE
Fixes accordion body padding for snippet files

### DIFF
--- a/src/app/components/snippet/snippet.component.scss
+++ b/src/app/components/snippet/snippet.component.scss
@@ -20,6 +20,10 @@ ngb-accordion {
         .card-body {
             padding: 0;
         }
+
+        .accordion-body {
+            padding: 0 !important;
+        }
     }
 }
 


### PR DESCRIPTION
Fixes the padding of the snippet acordion where the monaco editor is being loaded