### PR TITLE
Enable global scope, disable labels for global scope

### DIFF
--- a/src/app/components/snippet-options/snippet-options.component.html
+++ b/src/app/components/snippet-options/snippet-options.component.html
@@ -42,24 +42,28 @@
         </button>
       </div>
 
-      <div style="margin-top: 15px" *appPerm="'canEditSnippet'; args: [currentUser, activeSnippet]">
-        <div ngbDropdown class="d-inline-block" placement="bottom-right" #myDrop="ngbDropdown">
-          <button class="btn btn-sm btn-outline-primary" id="dropdownBasic1" ngbDropdownToggle>Labels</button>
-          <div ngbDropdownMenu aria-labelledby="dropdownBasic1">
-            <perfect-scrollbar style="max-height: 40vh">
-              <app-bootstrap-switch
-                class="label-toggle"
-                (click)="$event.stopPropagation(); myDrop.open()"
-                *ngFor="let label of labels$ | async; trackBy: trackByFn"
-                size="sm"
-                [label]="label.name"
-                [ngModel]="activeLabels.indexOf(label.pk) > -1"
-                (ngModelChange)="toggleLabel(label)"
-              ></app-bootstrap-switch>
-            </perfect-scrollbar>
+      <ng-container *ngIf="labels$ | async as loadedLabels">
+        <ng-container *ngIf="loadedLabels.length">
+          <div style="margin-top: 15px" *appPerm="'canEditSnippet'; args: [currentUser, activeSnippet]">
+            <div ngbDropdown class="d-inline-block" placement="bottom-right" #myDrop="ngbDropdown">
+              <button class="btn btn-sm btn-outline-primary" id="dropdownBasic1" ngbDropdownToggle>Labels</button>
+              <div ngbDropdownMenu aria-labelledby="dropdownBasic1">
+                <perfect-scrollbar style="max-height: 40vh">
+                  <app-bootstrap-switch
+                    class="label-toggle"
+                    (click)="$event.stopPropagation(); myDrop.open()"
+                    *ngFor="let label of loadedLabels; trackBy: trackByFn"
+                    size="sm"
+                    [label]="label.name"
+                    [ngModel]="activeLabels.indexOf(label.pk) > -1"
+                    (ngModelChange)="toggleLabel(label)"
+                  ></app-bootstrap-switch>
+                </perfect-scrollbar>
+              </div>
+            </div>
           </div>
-        </div>
-      </div>
+        </ng-container>
+      </ng-container>
     </div>
   </div>
 

--- a/src/app/components/view-switch/view-switch.component.html
+++ b/src/app/components/view-switch/view-switch.component.html
@@ -2,7 +2,7 @@
   <span class="user" (click)="loadUser()">
     <fa-icon icon="user"></fa-icon>
   </span>
-  <span class="user visually-hidden" (click)="loadGlobal()">
+  <span class="user visually" (click)="loadGlobal()">
     <fa-icon icon="globe"></fa-icon>
   </span>
 </div>

--- a/src/app/layout/sidebar/sidebar.component.html
+++ b/src/app/layout/sidebar/sidebar.component.html
@@ -16,7 +16,7 @@
             <app-view-info></app-view-info>
             <perfect-scrollbar style="max-height: calc(100vh - 87px - 0.75rem)" class="navigation">
               <app-menu></app-menu>
-              <app-labels></app-labels>
+              <app-labels *ngIf="scope && (scope.area === 'team' || scope.area === 'user')"></app-labels>
               <app-languages></app-languages>
               <app-team-members *ngIf="scope && scope.area === 'team'"></app-team-members>
             </perfect-scrollbar>

--- a/src/app/modals/snippet-modal/snippet-modal.component.html
+++ b/src/app/modals/snippet-modal/snippet-modal.component.html
@@ -11,15 +11,18 @@
     <span>Title</span>
     <anx-forms-input formControlName="title" [errors]="snippetForm.get('title').errors"></anx-forms-input>
 
-    <span>Labels</span>
-    <anx-forms-input-select
-      bindLabel="name"
-      bindValue="pk"
-      [options]="labels"
-      [multiple]="true"
-      formControlName="labels"
-      [errors]="snippetForm.get('labels').errors"
-    ></anx-forms-input-select>
+    <ng-container *ngIf="labels?.length">
+      <span>Labels</span>
+      <anx-forms-input-select
+        bindLabel="name"
+        bindValue="pk"
+        [options]="labels"
+        [multiple]="true"
+        formControlName="labels"
+        *ngIf="scope && (scope.area === 'team' || scope.area === 'user')"
+        [errors]="snippetForm.get('labels').errors"
+      ></anx-forms-input-select>
+    </ng-container>
 
     <span>Description</span>
     <anx-forms-input-textarea formControlName="description" [errors]="snippetForm.get('description').errors"></anx-forms-input-textarea>

--- a/src/app/state/label/label.state.ts
+++ b/src/app/state/label/label.state.ts
@@ -37,6 +37,9 @@ export class LabelState {
         const team = scope.value as ResourceModel<Team>;
         payload['team'] = team.pk;
         break;
+      case 'global':
+        ctx.setState([]);
+        return;
     }
 
     ctx.setState(await this.labelResource.query({ ...payload }).$promise);


### PR DESCRIPTION
Implements https://github.com/snypy/snypy-frontend/issues/1096

A new global scope is enabled, which adds new funtionality:
- allows to search for all snippets a user has access to (personal, team assignment or public snippets)
- textual search based on snippet content and filtering by file extension (as in personal or team scope)

Labels are not available in the global scope as these are entities that are bound to a user or a team.


