### PR TITLE
Fixes share view scroll layout

### DIFF
--- a/src/app/layout/fullscreen/fullscreen.component.html
+++ b/src/app/layout/fullscreen/fullscreen.component.html
@@ -9,7 +9,7 @@
     <div class="row">
       <div class="col-12 full-height remove-side-padding">
         <app-snippet-options></app-snippet-options>
-        <ng-scrollbar style="max-height: calc(100vh - 220px)" visibility="hover" class="snypy-scrollbar">
+        <ng-scrollbar style="height: calc(100vh - 155px)" visibility="hover" class="snypy-scrollbar">
           <app-snippet></app-snippet>
         </ng-scrollbar>
       </div>


### PR DESCRIPTION
Fixes the scroll layout on the share pages, which is currently cut 115 pixels

![image](https://github.com/snypy/snypy-frontend/assets/4420927/45dd67f8-9883-4b6a-9901-81d9b0f90198)
