### PR TITLE
Add copy button for markdown code blocks and inline code

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -33,7 +33,7 @@
                 "src/"
               ]
             },
-            "scripts": [],
+            "scripts": ["node_modules/clipboard/dist/clipboard.min.js"],
             "vendorChunk": true,
             "extractLicenses": false,
             "buildOptimizer": false,
@@ -90,7 +90,7 @@
             "karmaConfig": "./karma.conf.js",
             "polyfills": "src/polyfills.ts",
             "tsConfig": "src/tsconfig.spec.json",
-            "scripts": [],
+            "scripts": ["node_modules/clipboard/dist/clipboard.min.js"],
             "styles": [
               "node_modules/bootstrap/dist/css/bootstrap.min.css",
               "node_modules/@ng-select/ng-select/themes/default.theme.css",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@popperjs/core": "^2.11.8",
         "@snypy/rest-client": "^1.5.2",
         "bootstrap": "^5.3.8",
+        "clipboard": "^2.0.11",
         "core-js": "^3.49.0",
         "fs-extra": "^11.3.5",
         "karma-coverage": "^2.2.1",
@@ -5057,6 +5058,33 @@
         "node": ">=8"
       }
     },
+    "node_modules/@ngx-formly/schematics/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/@ngx-formly/schematics/node_modules/cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -5081,6 +5109,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@ngx-formly/schematics/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@ngx-formly/schematics/node_modules/is-interactive": {
@@ -5178,6 +5221,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@ngx-formly/schematics/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@ngx-formly/schematics/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
     "node_modules/@ngx-formly/schematics/node_modules/restore-cursor": {
@@ -8518,6 +8591,17 @@
         "node": ">= 12"
       }
     },
+    "node_modules/clipboard": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.11.tgz",
+      "integrity": "sha512-C+0bbOqkezLIsmWSvlsXS0Q0bmkugu7jcfMIACB+RDEntIzQIkdr148we28AfSloQLRdZlYL/QYyrq05j/3Faw==",
+      "license": "MIT",
+      "dependencies": {
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
+      }
+    },
     "node_modules/cliui": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
@@ -9283,6 +9367,12 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
+      "license": "MIT"
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -10783,6 +10873,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha512-goW1b+d9q/HIwbVYZzZ6SsTr4IgE+WA44A0GmPIQstuOrgsFcT7VEJ48nmr9GaRtNu0XTKacFLGnBPAM6Afouw==",
+      "license": "MIT",
+      "dependencies": {
+        "delegate": "^3.1.2"
       }
     },
     "node_modules/gopd": {
@@ -16068,6 +16167,12 @@
         }
       }
     },
+    "node_modules/select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha512-OwpTSOfy6xSs1+pwcNrv0RBMOzI39Lp3qQKUTPVVPRjCdNa5JH/oPRiqsesIskK8TVgmRiHwO4KXlV2Li9dANA==",
+      "license": "MIT"
+    },
     "node_modules/select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -17187,6 +17292,12 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
       "license": "MIT"
     },
     "node_modules/tinyglobby": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@popperjs/core": "^2.11.8",
     "@snypy/rest-client": "^1.5.2",
     "bootstrap": "^5.3.8",
+    "clipboard": "^2.0.11",
     "core-js": "^3.49.0",
     "fs-extra": "^11.3.5",
     "karma-coverage": "^2.2.1",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -42,6 +42,7 @@ import { MenuComponent } from './components/menu/menu.component';
 import { SetPasswordComponent } from './components/set-password/set-password.component';
 import { SnippetOptionsComponent } from './components/snippet-options/snippet-options.component';
 import { SnippetOrderComponent } from './components/snippet-order/snippet-order.component';
+import { MarkdownClipboardButtonComponent } from './components/markdown-clipboard-button/markdown-clipboard-button.component';
 import { SnippetComponent } from './components/snippet/snippet.component';
 import { SnippetsComponent } from './components/snippets/snippets.component';
 import { TeamMembersComponent } from './components/team-members/team-members.component';
@@ -136,6 +137,7 @@ export function apiConfigFactory(): Configuration {
     MenuComponent,
     SnippetsComponent,
     SnippetComponent,
+    MarkdownClipboardButtonComponent,
     SnippetOptionsComponent,
     FooterComponent,
     HeaderComponent,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -49,6 +49,7 @@ import { TeamMembersComponent } from './components/team-members/team-members.com
 import { TeamsComponent } from './components/teams/teams.component';
 import { ViewInfoComponent } from './components/view-info/view-info.component';
 import { ViewSwitchComponent } from './components/view-switch/view-switch.component';
+import { CopyInlineCodeDirective } from './directives/copy-inline-code/copy-inline-code.directive';
 import { PermDirective } from './directives/perm/perm.directive';
 import { JwtInterceptor } from './helpers/jwt.interceptor';
 import { LoadingScreenInterceptor } from './helpers/loading.interceptor';
@@ -160,6 +161,7 @@ export function apiConfigFactory(): Configuration {
     BootstrapSwitchComponent,
     LoadingScreenComponent,
     PermDirective,
+    CopyInlineCodeDirective,
     AuthComponent,
     RegisterComponent,
     RegisterCompleteComponent,

--- a/src/app/components/markdown-clipboard-button/markdown-clipboard-button.component.html
+++ b/src/app/components/markdown-clipboard-button/markdown-clipboard-button.component.html
@@ -1,0 +1,2 @@
+<button *ngIf="!copied" class="btn btn-sm btn-outline-primary copy-button" (click)="onCopied()">copy</button>
+<button *ngIf="copied" class="btn btn-sm btn-outline-success copy-button disabled">copied</button>

--- a/src/app/components/markdown-clipboard-button/markdown-clipboard-button.component.spec.ts
+++ b/src/app/components/markdown-clipboard-button/markdown-clipboard-button.component.spec.ts
@@ -1,0 +1,43 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+
+import { MarkdownClipboardButtonComponent } from './markdown-clipboard-button.component';
+
+describe('MarkdownClipboardButtonComponent', () => {
+  let component: MarkdownClipboardButtonComponent;
+  let fixture: ComponentFixture<MarkdownClipboardButtonComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [MarkdownClipboardButtonComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MarkdownClipboardButtonComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should switch to copied state on click', () => {
+    const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+    button.click();
+    fixture.detectChanges();
+
+    expect(component.copied).toBeTrue();
+    expect(fixture.nativeElement.textContent).toContain('copied');
+  });
+
+  it('should reset copied state after timeout', done => {
+    component.onCopied();
+    expect(component.copied).toBeTrue();
+
+    setTimeout(() => {
+      expect(component.copied).toBeFalse();
+      done();
+    }, 2100);
+  });
+});

--- a/src/app/components/markdown-clipboard-button/markdown-clipboard-button.component.ts
+++ b/src/app/components/markdown-clipboard-button/markdown-clipboard-button.component.ts
@@ -1,0 +1,28 @@
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy } from '@angular/core';
+
+@Component({
+  selector: 'app-markdown-clipboard-button',
+  templateUrl: './markdown-clipboard-button.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
+  standalone: false,
+})
+export class MarkdownClipboardButtonComponent implements OnDestroy {
+  copied = false;
+
+  private resetTimeout: ReturnType<typeof setTimeout>;
+
+  constructor(private cdr: ChangeDetectorRef) {}
+
+  onCopied(): void {
+    this.copied = true;
+    clearTimeout(this.resetTimeout);
+    this.resetTimeout = setTimeout(() => {
+      this.copied = false;
+      this.cdr.markForCheck();
+    }, 2000);
+  }
+
+  ngOnDestroy(): void {
+    clearTimeout(this.resetTimeout);
+  }
+}

--- a/src/app/components/snippet/snippet.component.html
+++ b/src/app/components/snippet/snippet.component.html
@@ -8,7 +8,13 @@
   </div>
 
   <div style="padding: 15px">
-    <markdown ngPreserveWhitespaces clipboard [clipboardButtonComponent]="clipboardButton" [data]="activeSnippet.description"></markdown>
+    <markdown
+      ngPreserveWhitespaces
+      clipboard
+      appCopyInlineCode
+      [clipboardButtonComponent]="clipboardButton"
+      [data]="activeSnippet.description"
+    ></markdown>
   </div>
 
   <div *ngFor="let file of files$ | async" style="margin: 20px" #container>

--- a/src/app/components/snippet/snippet.component.html
+++ b/src/app/components/snippet/snippet.component.html
@@ -8,7 +8,7 @@
   </div>
 
   <div style="padding: 15px">
-    <markdown ngPreserveWhitespaces [data]="activeSnippet.description"></markdown>
+    <markdown ngPreserveWhitespaces clipboard [clipboardButtonComponent]="clipboardButton" [data]="activeSnippet.description"></markdown>
   </div>
 
   <div *ngFor="let file of files$ | async" style="margin: 20px" #container>

--- a/src/app/components/snippet/snippet.component.ts
+++ b/src/app/components/snippet/snippet.component.ts
@@ -8,6 +8,7 @@ import { Label } from '@snypy/rest-client';
 import { Language, Snippet } from '@snypy/rest-client';
 import { LabelState } from '../../state/label/label.state';
 import { LanguageState } from '../../state/language/language.state';
+import { MarkdownClipboardButtonComponent } from '../markdown-clipboard-button/markdown-clipboard-button.component';
 
 @UntilDestroy()
 @Component({
@@ -18,6 +19,8 @@ import { LanguageState } from '../../state/language/language.state';
   standalone: false,
 })
 export class SnippetComponent implements OnInit {
+  public readonly clipboardButton = MarkdownClipboardButtonComponent;
+
   public copiedFile: File | null = null;
   public timer = null;
 

--- a/src/app/directives/copy-inline-code/copy-inline-code.directive.spec.ts
+++ b/src/app/directives/copy-inline-code/copy-inline-code.directive.spec.ts
@@ -1,0 +1,65 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ClipboardService } from 'ngx-clipboard';
+import { ToastrService } from 'ngx-toastr';
+
+import { CopyInlineCodeDirective } from './copy-inline-code.directive';
+
+@Component({
+  template: `<div appCopyInlineCode>
+    <code>inline code</code>
+    <pre><code>block code</code></pre>
+  </div>`,
+  standalone: false,
+})
+class TestHostComponent {}
+
+describe('CopyInlineCodeDirective', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let clipboardService: jasmine.SpyObj<ClipboardService>;
+  let toastr: jasmine.SpyObj<ToastrService>;
+
+  beforeEach(waitForAsync(() => {
+    clipboardService = jasmine.createSpyObj('ClipboardService', ['copyFromContent']);
+    toastr = jasmine.createSpyObj('ToastrService', ['success']);
+
+    TestBed.configureTestingModule({
+      declarations: [CopyInlineCodeDirective, TestHostComponent],
+      providers: [
+        { provide: ClipboardService, useValue: clipboardService },
+        { provide: ToastrService, useValue: toastr },
+      ],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+  });
+
+  it('should copy inline code on click', () => {
+    clipboardService.copyFromContent.and.returnValue(true);
+
+    const inlineCode: HTMLElement = fixture.nativeElement.querySelector('div > code');
+    inlineCode.click();
+
+    expect(clipboardService.copyFromContent).toHaveBeenCalledWith('inline code');
+    expect(toastr.success).toHaveBeenCalledWith('Copied to clipboard');
+  });
+
+  it('should ignore code inside pre blocks', () => {
+    const blockCode: HTMLElement = fixture.nativeElement.querySelector('pre > code');
+    blockCode.click();
+
+    expect(clipboardService.copyFromContent).not.toHaveBeenCalled();
+  });
+
+  it('should not notify when copy fails', () => {
+    clipboardService.copyFromContent.and.returnValue(false);
+
+    const inlineCode: HTMLElement = fixture.nativeElement.querySelector('div > code');
+    inlineCode.click();
+
+    expect(toastr.success).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/directives/copy-inline-code/copy-inline-code.directive.ts
+++ b/src/app/directives/copy-inline-code/copy-inline-code.directive.ts
@@ -1,0 +1,30 @@
+import { Directive, HostListener } from '@angular/core';
+import { ClipboardService } from 'ngx-clipboard';
+import { ToastrService } from 'ngx-toastr';
+
+/**
+ * Copies the content of inline code elements (single backticks in markdown)
+ * on click. Code blocks inside <pre> are handled by the ngx-markdown
+ * clipboard plugin instead.
+ */
+@Directive({
+  selector: '[appCopyInlineCode]',
+  standalone: false,
+})
+export class CopyInlineCodeDirective {
+  public constructor(
+    private clipboardService: ClipboardService,
+    private toastr: ToastrService
+  ) {}
+
+  @HostListener('click', ['$event'])
+  public onClick(event: MouseEvent): void {
+    const target = event.target as HTMLElement;
+
+    if (target.tagName === 'CODE' && !target.closest('pre')) {
+      if (this.clipboardService.copyFromContent(target.innerText)) {
+        this.toastr.success('Copied to clipboard');
+      }
+    }
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -30,5 +30,15 @@
   .snypy-scrollbar {
     --scrollbar-padding: 0px;
   }
+
+  // copy button for markdown code blocks, shown on hover only
+  .markdown-clipboard-toolbar {
+    opacity: 0;
+    transition: opacity 250ms ease-out;
+
+    &.hover {
+      opacity: 1;
+    }
+  }
 }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -40,5 +40,15 @@
       opacity: 1;
     }
   }
+
+  // inline code copies on click, see CopyInlineCodeDirective
+  markdown code:not(pre code) {
+    cursor: pointer;
+
+    &:hover {
+      background-color: #{$secondary-color-100};
+      border-radius: 2px;
+    }
+  }
 }
 


### PR DESCRIPTION
Introduces a new feature that enables users to easily copy inline and block code snippets from markdown-rendered content. It adds a custom copy button for markdown code blocks and allows inline code to be copied with a click. The implementation includes a new Angular component, a directive, supporting tests, and required style and configuration updates.
